### PR TITLE
Fix arm64 build against current toolchain

### DIFF
--- a/src/MMU_timing.h
+++ b/src/MMU_timing.h
@@ -155,8 +155,8 @@ private:
 	enum { ASSOCIATIVITY = 1 << ASSOCIATIVESHIFT };
 	enum { BLOCKSIZE = 1 << BLOCKSIZESHIFT };
 	enum { TAGSHIFT = SIZESHIFT - ASSOCIATIVESHIFT };
-	enum { TAGMASK = (u32)(~0 << TAGSHIFT) };
-	enum { BLOCKMASK = ((u32)~0 >> (32 - TAGSHIFT)) & (u32)(~0 << BLOCKSIZESHIFT) };
+	enum { TAGMASK = (u32)(~0u << TAGSHIFT) };
+	enum { BLOCKMASK = ((u32)~0u >> (32 - TAGSHIFT)) & (u32)(~0u << BLOCKSIZESHIFT) };
 	enum { WORDSIZE = sizeof(u32) };
 	enum { WORDSPERBLOCK = (1 << BLOCKSIZESHIFT) / WORDSIZE };
 	enum { DATAPERWORD = WORDSIZE * ASSOCIATIVITY };

--- a/src/cocoa/DeSmuME (Latest).xcodeproj/project.pbxproj
+++ b/src/cocoa/DeSmuME (Latest).xcodeproj/project.pbxproj
@@ -3564,6 +3564,7 @@
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_OBJC_ARC = YES;
+				OTHER_CPLUSPLUSFLAGS = "$(inherited) -Wno-c++11-narrowing";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SRCROOT)/openemu\"",
@@ -3584,6 +3585,7 @@
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_OBJC_ARC = YES;
+				OTHER_CPLUSPLUSFLAGS = "$(inherited) -Wno-c++11-narrowing";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SRCROOT)/openemu\"",

--- a/src/cocoa/cocoa_input.h
+++ b/src/cocoa/cocoa_input.h
@@ -129,8 +129,8 @@ typedef struct
 @property (assign) BOOL softwareMicState;
 @property (assign) NSInteger softwareMicMode;
 @property (assign) NSInteger micMode;
-@property (readonly, strong) CoreAudioInput *CAInputDevice;
-@property (readonly, strong) AudioGenerator *softwareMicSampleGenerator;
+@property (readonly, assign) CoreAudioInput *CAInputDevice;
+@property (readonly, assign) AudioGenerator *softwareMicSampleGenerator;
 @property (assign) AudioSampleBlockGenerator *selectedAudioFileGenerator;
 @property (assign) NSInteger paddleAdjust;
 @property (copy) NSString *hardwareMicInfoString;

--- a/src/utils/libfat/directory.cpp
+++ b/src/utils/libfat/directory.cpp
@@ -139,7 +139,7 @@ static size_t _FAT_directory_mbstoucs2 (ucs2_t* dst, const char* src, size_t len
 	int bytes;
 	size_t count = 0;
 
-	while (count < len-1 && src != '\0') {
+	while (count < len-1 && *src != '\0') {
 		bytes = mbrtowc (&tempChar, src, MB_CUR_MAX, &ps);
 		if (bytes > 0) {
 			*dst = (ucs2_t)tempChar;

--- a/src/wifi.cpp
+++ b/src/wifi.cpp
@@ -314,9 +314,9 @@ WifiComInterface* wifiCom;
 
 #if (WIFI_LOGGING_LEVEL >= 1)
 	#if WIFI_LOG_USE_LOGC
-		#define WIFI_LOG(level, ...) if(level <= WIFI_LOGGING_LEVEL) LOGC(8, "WIFI: "__VA_ARGS__);
+		#define WIFI_LOG(level, ...) if(level <= WIFI_LOGGING_LEVEL) LOGC(8, "WIFI: " __VA_ARGS__);
 	#else
-		#define WIFI_LOG(level, ...) if(level <= WIFI_LOGGING_LEVEL) printf("WIFI: "__VA_ARGS__);
+		#define WIFI_LOG(level, ...) if(level <= WIFI_LOGGING_LEVEL) printf("WIFI: " __VA_ARGS__);
 	#endif
 #else
 #define WIFI_LOG(level, ...) {}
@@ -329,7 +329,7 @@ WifiComInterface* wifiCom;
  *******************************************************************************/
 
 // TODO: find the right value
-// GBAtek says it is 10µs, however that value seems too small
+// GBAtek says it is 10ï¿½s, however that value seems too small
 // (MP host sends floods of data frames, clients can't keep up)
 // 100 would make more sense since CMDCOUNT is set to 166
 // that would be 16.6ms ~= 1 frame
@@ -1283,7 +1283,7 @@ void WIFI_write16(u32 address, u16 val)
 			wifiMac.eCountEnable = BIT0(val);
 			break;
 		case REG_WIFI_EXTRACOUNT:
-			WIFI_LOG(3, "EXTRACOUNT=%i (%i µs)\n", val, val*WIFI_CMDCOUNT_SLICE);
+			WIFI_LOG(3, "EXTRACOUNT=%i (%i ï¿½s)\n", val, val*WIFI_CMDCOUNT_SLICE);
 			wifiMac.eCount = (u32)val * WIFI_CMDCOUNT_SLICE;
 			break;
 		case REG_WIFI_LISTENINT:

--- a/src/wifi.cpp
+++ b/src/wifi.cpp
@@ -329,7 +329,7 @@ WifiComInterface* wifiCom;
  *******************************************************************************/
 
 // TODO: find the right value
-// GBAtek says it is 10�s, however that value seems too small
+// GBAtek says it is 10µs, however that value seems too small
 // (MP host sends floods of data frames, clients can't keep up)
 // 100 would make more sense since CMDCOUNT is set to 166
 // that would be 16.6ms ~= 1 frame


### PR DESCRIPTION
DeSmuME does not compile under current Xcode. The fixes:

- A logging macro concatenated a string literal directly against a macro
  argument with no separating space; C++11 parses that as a user-defined
  literal. Added the space.
- A cache controller left-shifted a signed `-1` in enum initializers,
  which is undefined behavior and rejected by current clang in a constant
  expression. Made the shifted operands unsigned.
- A multibyte-string helper compared a `char` pointer against `'\0'`
  instead of the character it points to. Added the dereference.
- Two properties typed as C++ class pointers were declared `strong`; ARC
  ownership does not apply to non-object pointers. Changed to `assign`.
- Base64 code has the same intentional narrowing in braced initializers
  as Nestopia; `-Wc++11-narrowing` is disabled for the plug-in target.

Builds arm64 against the macOS 26 SDK.
